### PR TITLE
Few additions

### DIFF
--- a/Classes/XCEViewClickerWindowController.m
+++ b/Classes/XCEViewClickerWindowController.m
@@ -27,6 +27,17 @@
         
 		NSView *view = [[event.window contentView] hitTest:[event locationInWindow]];
 
+        // If we didn't found view in contentView check toolbar
+        if( !view ){
+            for( NSToolbarItem *toolbarItem in event.window.toolbar.visibleItems ){
+                NSRect rectInWindow = [toolbarItem.view convertRect:toolbarItem.view.bounds toView:nil];
+                if( CGRectContainsPoint(rectInWindow, [event locationInWindow]) ){
+                    view = toolbarItem.view;
+                    break;
+                }
+            }
+        }
+        
 		NSString *info = @"";
 		if ([view isKindOfClass:[NSControl class]]) {
 			NSControl *control = (NSButton *)view;


### PR DESCRIPTION
don't track clicks on own pane window to enable copying of text
use window of event because keyWindow might have different position and not key one
if view wasn't found in contentView, check toolbar for it
